### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme-checker.yaml
+++ b/.github/workflows/readme-checker.yaml
@@ -1,4 +1,6 @@
 name: markdown-lint
+permissions:
+  contents: read
 on:
   pull_request:
 jobs:


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/SolidCore/security/code-scanning/2](https://github.com/gvatsal60/SolidCore/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository's contents to lint Markdown files, we will set `contents: read` as the minimal required permission. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
