### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build Project
+permissions:
+  contents: read
 on:
   push:
     branches: ["master"]


### PR DESCRIPTION
Potential fix for [https://github.com/gvatsal60/SolidCore/security/code-scanning/1](https://github.com/gvatsal60/SolidCore/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function. Since the workflow involves checking out the repository and running build and test commands, it likely only requires `contents: read` permission. This ensures that the `GITHUB_TOKEN` has limited access and adheres to the principle of least privilege.

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or within the specific job (`build`) to limit permissions for that job only. In this case, adding it at the root level is sufficient and simplifies the configuration.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
