### PR TITLE
Update postCreateScript.sh

### DIFF
--- a/.devcontainer/postCreateScript.sh
+++ b/.devcontainer/postCreateScript.sh
@@ -47,7 +47,7 @@ readonly ALIAS_SRC_URL="https://raw.githubusercontent.com/gvatsal60/Linux-Aliase
 # Install Linux aliases from external script using curl and execute immediately
 # Note: Make sure to review scripts fetched from external sources for security reasons
 if command -v curl >/dev/null 2>&1; then
-    curl -fsSL ${ALIAS_SRC_URL} | sh
+    curl -fsSL "${ALIAS_SRC_URL}" | sh
 else
     echo "Error: curl is not installed. Unable to use Linux aliases"
     exit 1


### PR DESCRIPTION
This pull request makes a minor update to the `postCreateScript.sh` file, improving the way the `ALIAS_SRC_URL` variable is referenced when using `curl`. The change ensures that the URL is correctly interpreted, especially if it contains special characters or spaces.

* Quoted the `ALIAS_SRC_URL` variable in the `curl` command to prevent issues with URLs containing special characters or spaces. (.devcontainer/postCreateScript.sh)