### PR TITLE
Update Dockerfile.debug

### DIFF
--- a/dockerfiles/Dockerfile.debug
+++ b/dockerfiles/Dockerfile.debug
@@ -15,7 +15,7 @@
 # ##########################################################################
 # Base Image
 # ##########################################################################
-FROM mcr.microsoft.com/devcontainers/cpp:latest AS base
+FROM mcr.microsoft.com/devcontainers/cpp:debian AS base
 
 # ##########################################################################
 # Maintainer


### PR DESCRIPTION
This pull request makes a minor update to the base image used in `dockerfiles/Dockerfile.debug`. The change switches the base image from the generic `cpp:latest` to the more specific `cpp:debian` variant, which may improve consistency and compatibility for builds.