### PR TITLE
Update devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -21,7 +21,7 @@
       ],
       "settings": {
         "[cpp]": {
-          "editor.defaultFormatter": "ms-vscode.cpptools"
+          "editor.defaultFormatter": "llvm-vs-code-extensions.vscode-clangd"
         },
         "clangd.checkUpdates": true,
         "clangd.inactiveRegions.useBackgroundHighlight": true,


### PR DESCRIPTION
This pull request makes a minor configuration change to the development container settings for C++ files. The default code formatter for C++ has been switched from `ms-vscode.cpptools` to `llvm-vs-code-extensions.vscode-clangd`.